### PR TITLE
Made benchmark command arguments passable through ros2 launch args

### DIFF
--- a/docs/scenarios/perception_pipeline_benchmark.md
+++ b/docs/scenarios/perception_pipeline_benchmark.md
@@ -25,7 +25,13 @@ export RMW_IMPLEMENTATION=rmw_zenoh_cpp # select your rmw_implementation to benc
 ros2 launch moveit_middleware_benchmark scenario_perception_pipeline_benchmark.launch.py
 ```
 
-It will be created the json file named `middleware_benchmark_results.json` for benchmarking results after finishing benchmark code execution. You can see the benchmark results in more detail inside this json file.
+It will be defaultly benchmarked with 6 repetitions using first test_case in [`scenario_perception_pipeline_test_cases.yaml`](../../config/scenario_perception_pipeline_test_cases.yaml) It will be created the json file named `middleware_benchmark_results.json` for benchmarking results after finishing benchmark code execution. You can see the benchmark results in more detail inside this json file.
+
+If you want to customize your benchmark arguments or select different test case, you can use below command.
+
+```shell
+ros2 launch moveit_middleware_benchmark scenario_perception_pipeline_benchmark.launch.py benchmark_command_args:="--benchmark_out=middleware_benchmark_results.json --benchmark_out_format=json --benchmark_repetitions=1" selected_test_case_index:=0
+```
 
 ## How to benchmark the perception pipeline
 


### PR DESCRIPTION
This PR is created for users to be able to pass custom benchmark arguments. 

In previous versions, it had to be modified launch file itself to set benchmark arguments. Now this arguments can be passed through commanline. 

For example:

```shell
ros2 launch moveit_middleware_benchmark scenario_perception_pipeline_benchmark.launch.py benchmark_command_args:="--benchmark_out=middleware_benchmark_results.json --benchmark_out_format=json --benchmark_repetitions=1" selected_test_case_index:=0
```

Thanks to https://answers.ros.org/question/396345/ros2-launch-file-how-to-convert-launchargument-to-string/