### PR TITLE
Switched to moveit's own dockerfile and fixed dependency repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:rolling
+FROM moveit/moveit2:rolling-source
 
 RUN apt-get update && \
     apt install wget -y
@@ -6,17 +6,17 @@ RUN apt-get update && \
 RUN mkdir ws/src -p
 
 RUN . /opt/ros/rolling/setup.sh && \
-    cd ws/src && \
+    cd /root/ws_moveit/src && \
     git clone https://github.com/CihatAltiparmak/moveit_middleware_benchmark.git && \
     vcs import < moveit_middleware_benchmark/moveit_middleware_benchmark.repos --recursive
 
 RUN . /opt/ros/rolling/setup.sh && \
-    cd ws && \
+    cd /root/ws_moveit && \
     rosdep update --rosdistro=$ROS_DISTRO && \
     apt-get update && \
     apt upgrade -y && \
     rosdep install --from-paths src --ignore-src -r -y
 
 RUN . /opt/ros/rolling/setup.sh && \
-    cd ws && \
+    cd /root/ws_moveit && \
     colcon build --mixin release --packages-skip test_dynmsg dynmsg_demo

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,17 @@ RUN apt-get update && \
 RUN mkdir ws/src -p
 
 RUN . /opt/ros/rolling/setup.sh && \
-    cd /root/ws_moveit/src && \
+    cd ${ROS_UNDERLAY}/../src && \
     git clone https://github.com/CihatAltiparmak/moveit_middleware_benchmark.git && \
     vcs import < moveit_middleware_benchmark/moveit_middleware_benchmark.repos --recursive
 
 RUN . /opt/ros/rolling/setup.sh && \
-    cd /root/ws_moveit && \
+    cd ${ROS_UNDERLAY}/.. && \
     rosdep update --rosdistro=$ROS_DISTRO && \
     apt-get update && \
     apt upgrade -y && \
     rosdep install --from-paths src --ignore-src -r -y
 
 RUN . /opt/ros/rolling/setup.sh && \
-    cd /root/ws_moveit && \
+    cd ${ROS_UNDERLAY}/.. && \
     colcon build --mixin release --packages-skip test_dynmsg dynmsg_demo

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,14 @@ RUN mkdir ws/src -p
 
 RUN . /opt/ros/rolling/setup.sh && \
     cd ws/src && \
-    git clone https://github.com/CihatAltiparmak/moveit_middleware_benchmark.git -b development && \
+    git clone https://github.com/CihatAltiparmak/moveit_middleware_benchmark.git && \
     vcs import < moveit_middleware_benchmark/moveit_middleware_benchmark.repos --recursive
-
-RUN cd ws/src && \
-    # git clone https://github.com/ros2/rmw_zenoh.git && \
-    git clone https://github.com/ros2/rmw_cyclonedds.git
 
 RUN . /opt/ros/rolling/setup.sh && \
     cd ws && \
     rosdep update --rosdistro=$ROS_DISTRO && \
     apt-get update && \
+    apt upgrade -y && \
     rosdep install --from-paths src --ignore-src -r -y
 
 RUN . /opt/ros/rolling/setup.sh && \

--- a/moveit_middleware_benchmark.repos
+++ b/moveit_middleware_benchmark.repos
@@ -1,5 +1,5 @@
 repositories:
-  moveit_msgs:
+  moveit2:
     type: git
     url: https://github.com/moveit/moveit2.git
     version: main
@@ -10,6 +10,14 @@ repositories:
   rmw_zenoh:
     type: git
     url: https://github.com/ros2/rmw_zenoh.git
+    version: rolling
+  rmw_cyclonedds:
+    type: git
+    url: https://github.com/ros2/rmw_cyclonedds.git
+    version: rolling
+  rmw_fastrtps:
+    type: git
+    url: https://github.com/ros2/rmw_fastrtps.git
     version: rolling
   dynamic_message_introspection:
     type: git

--- a/moveit_middleware_benchmark.repos
+++ b/moveit_middleware_benchmark.repos
@@ -1,8 +1,4 @@
 repositories:
-  moveit2:
-    type: git
-    url: https://github.com/moveit/moveit2.git
-    version: main
   moveit_resources:
     type: git
     url: https://github.com/moveit/moveit_resources.git


### PR DESCRIPTION
In rolling, we should upgrade before building workspace due to the fact that rolling is a version that updated continuously. Otherwise docker sometimes can fail. Additionaly, i have fixed some typos in dependency file.