### PR TITLE
Reconfigured run_benchmarks CI so that it can be conducted all moveit_benchmarks reliably

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -1,10 +1,10 @@
-name: Run MoveIt Middleware Benchmarks and Push Results
+name: Run MoveIt Middleware Benchmarks
 
-on: [push]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  run_middleware_benchmarks:
-    name: run_benchmarks
+  run_all_benchmarks:
+    name: run_all_benchmarks
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -12,25 +12,69 @@ jobs:
     container:
       image: ghcr.io/cihataltiparmak/moveit_middleware_benchmark:latest
     steps:
-      - name: run perception benchmark
+      - name: run benchmarks for rmw_fastrtps
         run: |
-          cd /ws
+          cd ${ROS_UNDERLAY}/..
           . /opt/ros/rolling/setup.sh
           . install/setup.sh
-          ros2 launch moveit_middleware_benchmark scenario_perception_pipeline_benchmark.launch.py
+          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_fastrtps/config_rmw_fastrtps.sh -d /benchmark_results -m rmw_fastrtps_cpp
+      - name: run benchmarks for rmw_cyclonedds
+        run: |
+          cd ${ROS_UNDERLAY}/..
+          . /opt/ros/rolling/setup.sh
+          . install/setup.sh
+          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_cyclonedds/config_rmw_cyclonedds.sh -d /benchmark_results -m rmw_cyclonedds_cpp
       - name: clone repo
         uses: actions/checkout@v3
       - name: add to safe directory
         run: |
           git config --global --add safe.directory /__w/moveit_middleware_benchmark/moveit_middleware_benchmark
-      - name: push perception benchmark results to github pages
+      - name: push perception benchmark results for rmw_fastrtps to github pages
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: Movet Middleware Benchmark Project Perception Pipeline Benchmark
+          name: Perception Pipeline Benchmark
           tool: 'googlecpp'
-          output-file-path: /ws/middleware_benchmark_results.json
+          output-file-path: /benchmark_results/scenario_perception_pipeline/rmw_fastrtps_cpp.json
           # Access token to deploy GitHub Pages branch
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true
           gh-pages-branch: "gh-pages"
+          benchmark-data-dir-path: "rmw_fastrtps"
+      - name: push simple service client benchmark results for rmw_fastrtps to github pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Basic Service Client Benchmark
+          tool: 'googlecpp'
+          output-file-path: /benchmark_results/scenario_basic_service_client/rmw_fastrtps_cpp.json
+          # Access token to deploy GitHub Pages branch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push and deploy GitHub pages branch automatically
+          auto-push: true
+          gh-pages-branch: "gh-pages"
+          benchmark-data-dir-path: "rmw_fastrtps"
+
+      - name: push perception benchmark results for rmw_cyclonedds to github pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Perception Pipeline Benchmark
+          tool: 'googlecpp'
+          output-file-path: /benchmark_results/scenario_perception_pipeline/rmw_cyclonedds_cpp.json
+          # Access token to deploy GitHub Pages branch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push and deploy GitHub pages branch automatically
+          auto-push: true
+          gh-pages-branch: "gh-pages"
+          benchmark-data-dir-path: "rmw_cyclonedds"
+      - name: push simple service client benchmark results for rme_cyclonedds to github pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Basic Service Client Benchmark
+          tool: 'googlecpp'
+          output-file-path: /benchmark_results/scenario_basic_service_client/rmw_cyclonedds_cpp.json
+          # Access token to deploy GitHub Pages branch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push and deploy GitHub pages branch automatically
+          auto-push: true
+          gh-pages-branch: "gh-pages"
+          benchmark-data-dir-path: "rmw_cyclonedds"


### PR DESCRIPTION
With this PR, it's aimed to conduct benchmark in github action and then to visualize all the benchmark results as well.

1) Using this repo's own docker image, we just run run_benchmarks.sh for each middleware. But all benchmarks run inside one job because it's not guarantied that github uses same machine in every job. This blocks the reliability of benchmarks which runs on github action's runners. For example:

![Screenshot from 2024-07-28 03-15-04](https://github.com/user-attachments/assets/4d09c4f3-6cd8-4b92-83b1-70e4c22b7618)

In above picture, you can see the plots related to the results of scenario basic service client. Until `133944c` commit, you can see the unreliable results. After  `133944c` commit, graph starts to show  the real plots. we still cannot guarantee comparison between commits, but seems we can at least guarantee the comparison in same commit between middlewares.