### PR TITLE
Set fail-fast param in github action jobs as false

### DIFF
--- a/.github/workflows/create_docker_image.yml
+++ b/.github/workflows/create_docker_image.yml
@@ -6,6 +6,8 @@ jobs:
   build_and_push_docker_image:
     name: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -6,6 +6,7 @@ jobs:
   industrial_ci:
     name: ROS ${{ matrix.ROS_DISTRO }} (${{ matrix.ROS_REPO }})
     strategy:
+      fail-fast: false
       matrix:
         ROS_DISTRO: [rolling]
         ROS_REPO: [testing, main]

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -6,6 +6,8 @@ jobs:
   run_middleware_benchmarks:
     name: run_benchmarks
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     permissions:
       contents: write
       deployments: write

--- a/.github/workflows/test_moveit_middleware_benchmark_action.yml
+++ b/.github/workflows/test_moveit_middleware_benchmark_action.yml
@@ -6,6 +6,8 @@ jobs:
   moveit_middleware_benchmark_github_action_test:
     name: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: ./


### PR DESCRIPTION
Github CIes are sometimes failed without any reason. I randomly have found it today. When i rerun the failed github jobs, it's interrupted without any reason. We should add this parameter to CI so that our CI  isn't interrupted without any reason. Btw industrial CI which ROS_REPO=testing still will be failed until the deprecated usage of rmw_localhost_only_t inside rmw_zenoh is removed. Can be ignored. You can also take a look at my relavant PR (https://github.com/ros2/rmw_zenoh/pull/255) 