### PR TITLE
Fixed deprecated usage of run_all_benchmarks.sh script in CI

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -19,13 +19,13 @@ jobs:
           cd ${ROS_UNDERLAY}/..
           . /opt/ros/rolling/setup.sh
           . install/setup.sh
-          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_fastrtps/config_rmw_fastrtps.sh -d /benchmark_results -m rmw_fastrtps_cpp
+          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_fastrtps/config_rmw_fastrtps.sh -d /benchmark_results
       - name: run benchmarks for rmw_cyclonedds
         run: |
           cd ${ROS_UNDERLAY}/..
           . /opt/ros/rolling/setup.sh
           . install/setup.sh
-          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_cyclonedds/config_rmw_cyclonedds.sh -d /benchmark_results -m rmw_cyclonedds_cpp
+          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_cyclonedds/config_rmw_cyclonedds.sh -d /benchmark_results
       - name: clone repo
         uses: actions/checkout@v3
       - name: add to safe directory

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -19,13 +19,13 @@ jobs:
           cd ${ROS_UNDERLAY}/..
           . /opt/ros/rolling/setup.sh
           . install/setup.sh
-          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_fastrtps/config_rmw_fastrtps.sh -d /benchmark_results
+          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_fastrtps/config.sh -d /benchmark_results
       - name: run benchmarks for rmw_cyclonedds
         run: |
           cd ${ROS_UNDERLAY}/..
           . /opt/ros/rolling/setup.sh
           . install/setup.sh
-          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_cyclonedds/config_rmw_cyclonedds.sh -d /benchmark_results
+          sh src/moveit_middleware_benchmark/scripts/run_all_benchmarks.sh -i ./src/moveit_middleware_benchmark/middleware_configurations/rmw_cyclonedds/config.sh -d /benchmark_results
       - name: clone repo
         uses: actions/checkout@v3
       - name: add to safe directory


### PR DESCRIPTION
I've realised i didn't remove some deprecated usage in running benchmarks' CI. Very easy job.